### PR TITLE
feat: support consumer concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,29 @@ class Application {
   }
 }
 ```
+
+### Concurrency
+
+Consumers in the SQS binder support the Spring Cloud Stream `concurrency` property.
+By specifying a value you will launch `concurrency`  threads continuously polling for `maxNumberOfMessages` each.
+The threads will process all messages asynchronously, but each thread will wait for its current batch of messages to all complete processing before retrieving new ones.
+If your message processing is highly variable from message to message it is recommended to set a lower value for `maxNumberOfMessages` and a higher value for `concurrency`.
+Note that this will increase the amount of API calls done against SQS.
+
+**Example Configuration:**
+
+```yaml
+spring:
+  cloud:
+    stream:
+      sqs:
+        bindings:
+          someFunction-in-0:
+            consumer:
+              maxNumberOfMessages: 5
+      bindings:
+        someFunction-in-0:
+          destination: input-queue-name
+          consumer:
+            concurrency: 10
+```

--- a/src/main/java/de/idealo/spring/stream/binder/sqs/SqsMessageHandlerBinder.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sqs/SqsMessageHandlerBinder.java
@@ -10,7 +10,6 @@ import org.springframework.cloud.stream.binder.ExtendedProducerProperties;
 import org.springframework.cloud.stream.binder.ExtendedPropertiesBinder;
 import org.springframework.cloud.stream.provisioning.ConsumerDestination;
 import org.springframework.cloud.stream.provisioning.ProducerDestination;
-import org.springframework.integration.aws.inbound.SqsMessageDrivenChannelAdapter;
 import org.springframework.integration.aws.outbound.SqsMessageHandler;
 import org.springframework.integration.channel.AbstractMessageChannel;
 import org.springframework.integration.core.MessageProducer;
@@ -19,6 +18,7 @@ import org.springframework.messaging.MessageHandler;
 
 import com.amazonaws.services.sqs.AmazonSQSAsync;
 
+import de.idealo.spring.stream.binder.sqs.inbound.SqsInboundChannelAdapter;
 import de.idealo.spring.stream.binder.sqs.properties.SqsConsumerProperties;
 import de.idealo.spring.stream.binder.sqs.properties.SqsExtendedBindingProperties;
 import de.idealo.spring.stream.binder.sqs.properties.SqsProducerProperties;
@@ -30,7 +30,7 @@ public class SqsMessageHandlerBinder
 
     private final AmazonSQSAsync amazonSQS;
     private final SqsExtendedBindingProperties extendedBindingProperties;
-    private final List<SqsMessageDrivenChannelAdapter> adapters = new ArrayList<>();
+    private final List<SqsInboundChannelAdapter> adapters = new ArrayList<>();
 
     public SqsMessageHandlerBinder(AmazonSQSAsync amazonSQS, SqsStreamProvisioner provisioningProvider, SqsExtendedBindingProperties extendedBindingProperties) {
         super(new String[0], provisioningProvider);
@@ -42,8 +42,8 @@ public class SqsMessageHandlerBinder
         return amazonSQS;
     }
 
-    public List<SqsMessageDrivenChannelAdapter> getAdapters() {
-        return adapters;
+    public List<SqsInboundChannelAdapter> getAdapters() {
+        return new ArrayList<>(adapters);
     }
 
     @Override
@@ -61,8 +61,9 @@ public class SqsMessageHandlerBinder
 
     @Override
     protected MessageProducer createConsumerEndpoint(ConsumerDestination destination, String group, ExtendedConsumerProperties<SqsConsumerProperties> properties) throws Exception {
-        SqsMessageDrivenChannelAdapter adapter = new SqsMessageDrivenChannelAdapter(amazonSQS, destination.getName());
+        SqsInboundChannelAdapter adapter = new SqsInboundChannelAdapter(amazonSQS, destination.getName());
         adapter.setMaxNumberOfMessages(properties.getExtension().getMaxNumberOfMessages());
+        adapter.setConcurrency(properties.getConcurrency());
         adapter.setVisibilityTimeout(properties.getExtension().getVisibilityTimeout());
         adapter.setWaitTimeOut(properties.getExtension().getWaitTimeout());
 

--- a/src/main/java/de/idealo/spring/stream/binder/sqs/health/SqsBinderHealthIndicator.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sqs/health/SqsBinderHealthIndicator.java
@@ -4,13 +4,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.health.AbstractHealthIndicator;
 import org.springframework.boot.actuate.health.Health;
-import org.springframework.integration.aws.inbound.SqsMessageDrivenChannelAdapter;
 import org.springframework.util.Assert;
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
 
 import de.idealo.spring.stream.binder.sqs.SqsMessageHandlerBinder;
+import de.idealo.spring.stream.binder.sqs.inbound.SqsInboundChannelAdapter;
 
 /**
  * Code from
@@ -36,7 +36,7 @@ public class SqsBinderHealthIndicator extends AbstractHealthIndicator {
             allListenersRunning = false;
         }
 
-        for (SqsMessageDrivenChannelAdapter adapter : this.sqsMessageHandlerBinder.getAdapters()) {
+        for (SqsInboundChannelAdapter adapter : this.sqsMessageHandlerBinder.getAdapters()) {
             for (String queueName : adapter.getQueues()) {
                 if (!adapter.isRunning(queueName)) {
                     builder.down().withDetail(queueName, "listener is not running");

--- a/src/main/java/de/idealo/spring/stream/binder/sqs/inbound/SqsInboundChannelAdapter.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sqs/inbound/SqsInboundChannelAdapter.java
@@ -1,0 +1,166 @@
+package de.idealo.spring.stream.binder.sqs.inbound;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.context.annotation.Scope;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.integration.aws.support.AwsHeaders;
+import org.springframework.integration.endpoint.MessageProducerSupport;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.messaging.handler.HandlerMethod;
+import org.springframework.stereotype.Component;
+import org.springframework.util.Assert;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+
+import io.awspring.cloud.core.env.ResourceIdResolver;
+import io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory;
+import io.awspring.cloud.messaging.listener.QueueMessageHandler;
+import io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer;
+import io.awspring.cloud.messaging.listener.SqsMessageDeletionPolicy;
+
+@Component
+@Scope("prototype")
+public class SqsInboundChannelAdapter extends MessageProducerSupport {
+
+    private final SimpleMessageListenerContainerFactory simpleMessageListenerContainerFactory = new SimpleMessageListenerContainerFactory();
+
+    private final String[] queues;
+
+    private final List<SimpleMessageListenerContainer> listenerContainers = new ArrayList<>();
+
+    private int concurrency = 1;
+
+    private Long queueStopTimeout;
+
+    private SqsMessageDeletionPolicy messageDeletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE;
+
+    public SqsInboundChannelAdapter(AmazonSQSAsync amazonSqs, String... queues) {
+        Assert.noNullElements(queues, "'queues' must not be empty");
+        this.simpleMessageListenerContainerFactory.setAmazonSqs(amazonSqs);
+        this.queues = Arrays.copyOf(queues, queues.length);
+    }
+
+    public void setTaskExecutor(AsyncTaskExecutor taskExecutor) {
+        this.simpleMessageListenerContainerFactory.setTaskExecutor(taskExecutor);
+    }
+
+    public void setMaxNumberOfMessages(Integer maxNumberOfMessages) {
+        this.simpleMessageListenerContainerFactory.setMaxNumberOfMessages(maxNumberOfMessages);
+    }
+
+    public void setConcurrency(int concurrency) {
+        this.concurrency = concurrency;
+    }
+
+    public void setVisibilityTimeout(Integer visibilityTimeout) {
+        this.simpleMessageListenerContainerFactory.setVisibilityTimeout(visibilityTimeout);
+    }
+
+    public void setWaitTimeOut(Integer waitTimeOut) {
+        this.simpleMessageListenerContainerFactory.setWaitTimeOut(waitTimeOut);
+    }
+
+    public void setResourceIdResolver(ResourceIdResolver resourceIdResolver) {
+        this.simpleMessageListenerContainerFactory.setResourceIdResolver(resourceIdResolver);
+    }
+
+    @Override
+    public void setAutoStartup(boolean autoStartUp) {
+        super.setAutoStartup(autoStartUp);
+        this.simpleMessageListenerContainerFactory.setAutoStartup(autoStartUp);
+    }
+
+    public void setDestinationResolver(DestinationResolver<String> destinationResolver) {
+        this.simpleMessageListenerContainerFactory.setDestinationResolver(destinationResolver);
+    }
+
+    public void setQueueStopTimeout(long queueStopTimeout) {
+        this.queueStopTimeout = queueStopTimeout;
+    }
+
+    public void setMessageDeletionPolicy(SqsMessageDeletionPolicy messageDeletionPolicy) {
+        Assert.notNull(messageDeletionPolicy, "'messageDeletionPolicy' must not be null.");
+        this.messageDeletionPolicy = messageDeletionPolicy;
+    }
+
+    @Override
+    protected void onInit() {
+        super.onInit();
+
+        for (int i = 0; i < concurrency; i++) {
+            SimpleMessageListenerContainer container = this.simpleMessageListenerContainerFactory.createSimpleMessageListenerContainer();
+            this.listenerContainers.add(container);
+            if (this.queueStopTimeout != null) {
+                container.setQueueStopTimeout(this.queueStopTimeout);
+            }
+            container.setMessageHandler(new IntegrationQueueMessageHandler());
+            try {
+                container.afterPropertiesSet();
+            } catch (Exception e) {
+                throw new BeanCreationException("Cannot instantiate 'SimpleMessageListenerContainer'", e);
+            }
+        }
+    }
+
+    @Override
+    protected void doStart() {
+        super.doStart();
+        this.listenerContainers.forEach(SimpleMessageListenerContainer::start);
+    }
+
+    @Override
+    protected void doStop() {
+        super.doStop();
+        this.listenerContainers.forEach(SimpleMessageListenerContainer::stop);
+    }
+
+    public boolean isRunning(String logicalQueueName) {
+        return this.listenerContainers.stream()
+                .anyMatch(container -> container.isRunning(logicalQueueName));
+    }
+
+    public String[] getQueues() {
+        return Arrays.copyOf(this.queues, this.queues.length);
+    }
+
+    @Override
+    public void destroy() {
+        this.listenerContainers.forEach(SimpleMessageListenerContainer::destroy);
+    }
+
+    private class IntegrationQueueMessageHandler extends QueueMessageHandler {
+
+        @Override
+        public Map<MappingInformation, HandlerMethod> getHandlerMethods() {
+            Set<String> uniqueQueues = new HashSet<>(Arrays.asList(SqsInboundChannelAdapter.this.queues));
+            MappingInformation mappingInformation = new MappingInformation(uniqueQueues,
+                    SqsInboundChannelAdapter.this.messageDeletionPolicy);
+            return Collections.singletonMap(mappingInformation, null);
+        }
+
+        @Override
+        protected void handleMessageInternal(Message<?> message, String lookupDestination) {
+            MessageHeaders headers = message.getHeaders();
+
+            Message<?> messageToSend = getMessageBuilderFactory().fromMessage(message)
+                    .removeHeaders("LogicalResourceId", "MessageId", "ReceiptHandle", "Acknowledgment")
+                    .setHeader(AwsHeaders.MESSAGE_ID, headers.get("MessageId"))
+                    .setHeader(AwsHeaders.RECEIPT_HANDLE, headers.get("ReceiptHandle"))
+                    .setHeader(AwsHeaders.RECEIVED_QUEUE, headers.get("LogicalResourceId"))
+                    .setHeader(AwsHeaders.ACKNOWLEDGMENT, headers.get("Acknowledgment")).build();
+
+            sendMessage(messageToSend);
+        }
+
+    }
+}

--- a/src/test/java/de/idealo/spring/stream/binder/sqs/SqsBinderConcurrencyTest.java
+++ b/src/test/java/de/idealo/spring/stream/binder/sqs/SqsBinderConcurrencyTest.java
@@ -1,0 +1,115 @@
+package de.idealo.spring.stream.binder.sqs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.health.HealthEndpoint;
+import org.springframework.boot.actuate.health.Status;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.support.MessageBuilder;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+import com.amazonaws.services.sqs.AmazonSQSAsyncClientBuilder;
+import com.amazonaws.services.sqs.model.Message;
+import com.amazonaws.services.sqs.model.SendMessageRequest;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Sinks;
+import reactor.test.StepVerifier;
+
+@Testcontainers
+@SpringBootTest(properties = {
+        "cloud.aws.stack.auto=false",
+        "cloud.aws.region.static=eu-central-1",
+        "spring.cloud.stream.bindings.input-in-0.destination=concurrentQueue",
+        "spring.cloud.stream.sqs.bindings.input-in-0.consumer.snsFanout=false",
+        "spring.cloud.stream.sqs.bindings.input-in-0.consumer.maxNumberOfMessages=1",
+        "spring.cloud.function.definition=input",
+        "spring.cloud.stream.bindings.input-in-0.consumer.concurrency=2"
+})
+class SqsBinderConcurrencyTest {
+
+    @Container
+    private static final LocalStackContainer localStack = new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.12.10"))
+            .withServices(SQS)
+            .withEnv("DEFAULT_REGION", "eu-central-1");
+
+    private static final Sinks.Many<String> inputSink = Sinks.many().multicast().onBackpressureBuffer();
+
+    @SpyBean
+    private AmazonSQSAsync amazonSQS;
+
+    @BeforeAll
+    static void beforeAll() throws Exception {
+        localStack.execInContainer("awslocal", "sqs", "create-queue", "--queue-name", "concurrentQueue");
+    }
+
+    @Test
+    void shouldPassMessageToConsumer() {
+        String queueUrl = amazonSQS.getQueueUrl("concurrentQueue").getQueueUrl();
+
+        amazonSQS.sendMessage(queueUrl, "delayedMessage");
+        amazonSQS.sendMessage(queueUrl, "processedMessage");
+
+        StepVerifier.create(inputSink.asFlux())
+                .assertNext(message -> {
+                    assertThat(message).isEqualTo("processedMessage");
+                })
+                .thenAwait(Duration.ofSeconds(1))
+                .assertNext(message -> {
+                    assertThat(message).isEqualTo("delayedMessage");
+                })
+                .verifyTimeout(Duration.ofSeconds(2));
+    }
+
+    @TestConfiguration
+    static class AwsConfig {
+
+        @Bean
+        AmazonSQSAsync amazonSQS() {
+            return AmazonSQSAsyncClientBuilder.standard()
+                    .withEndpointConfiguration(localStack.getEndpointConfiguration(SQS))
+                    .withCredentials(localStack.getDefaultCredentialsProvider())
+                    .build();
+        }
+
+        @Bean
+        Consumer<String> input() {
+            return (input) -> {
+                if("delayedMessage".equals(input)) {
+                    try {
+                        Thread.sleep(1000L);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                inputSink.tryEmitNext(input);
+            };
+        }
+    }
+
+    @SpringBootApplication
+    static class Application {
+    }
+}

--- a/src/test/java/de/idealo/spring/stream/binder/sqs/health/SqsBinderHealthIndicatorTest.java
+++ b/src/test/java/de/idealo/spring/stream/binder/sqs/health/SqsBinderHealthIndicatorTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.Status;
-import org.springframework.integration.aws.inbound.SqsMessageDrivenChannelAdapter;
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.services.sqs.AmazonSQSAsync;
@@ -24,6 +23,7 @@ import com.amazonaws.services.sqs.model.GetQueueUrlResult;
 import com.amazonaws.services.sqs.model.QueueDoesNotExistException;
 
 import de.idealo.spring.stream.binder.sqs.SqsMessageHandlerBinder;
+import de.idealo.spring.stream.binder.sqs.inbound.SqsInboundChannelAdapter;
 
 @ExtendWith(MockitoExtension.class)
 class SqsBinderHealthIndicatorTest {
@@ -35,7 +35,7 @@ class SqsBinderHealthIndicatorTest {
     private AmazonSQSAsync amazonSQS;
 
     @Mock
-    private SqsMessageDrivenChannelAdapter adapter;
+    private SqsInboundChannelAdapter adapter;
 
     @InjectMocks
     private SqsBinderHealthIndicator healthIndicator;

--- a/src/test/java/de/idealo/spring/stream/binder/sqs/inbound/SqsInboundChannelAdapterTest.java
+++ b/src/test/java/de/idealo/spring/stream/binder/sqs/inbound/SqsInboundChannelAdapterTest.java
@@ -1,0 +1,214 @@
+package de.idealo.spring.stream.binder.sqs.inbound;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.messaging.core.DestinationResolver;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.amazonaws.services.sqs.AmazonSQSAsync;
+
+import io.awspring.cloud.core.env.ResourceIdResolver;
+import io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory;
+import io.awspring.cloud.messaging.listener.SimpleMessageListenerContainer;
+
+@ExtendWith(MockitoExtension.class)
+class SqsInboundChannelAdapterTest {
+    @Mock
+    private AmazonSQSAsync amazonSQS;
+
+    @Mock
+    private SimpleMessageListenerContainerFactory listenerContainerFactory;
+
+    @Mock
+    private SimpleMessageListenerContainer listenerContainer;
+
+    @Test
+    void shouldDefaultToSingleListenerContainer() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+        when(listenerContainerFactory.createSimpleMessageListenerContainer()).thenReturn(listenerContainer);
+
+        sut.afterPropertiesSet();
+
+        verify(listenerContainerFactory, times(1)).createSimpleMessageListenerContainer();
+    }
+
+    @Test
+    void shouldCreateMultipleListenerContainers() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+        when(listenerContainerFactory.createSimpleMessageListenerContainer()).thenReturn(listenerContainer);
+
+        sut.setConcurrency(3);
+        sut.afterPropertiesSet();
+
+        verify(listenerContainerFactory, times(3)).createSimpleMessageListenerContainer();
+    }
+
+    @Test
+    void shouldStartAllListenerContainers() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+        when(listenerContainerFactory.createSimpleMessageListenerContainer()).thenReturn(listenerContainer);
+
+        sut.setConcurrency(3);
+        sut.afterPropertiesSet();
+        sut.doStart();
+
+        verify(listenerContainer, times(3)).start();
+    }
+
+    @Test
+    void shouldStopAllListenerContainers() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+        when(listenerContainerFactory.createSimpleMessageListenerContainer()).thenReturn(listenerContainer);
+
+        sut.setConcurrency(3);
+        sut.afterPropertiesSet();
+        sut.doStop();
+
+        verify(listenerContainer, times(3)).stop();
+    }
+
+    @Test
+    void shouldDestroyAllListenerContainers() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+        when(listenerContainerFactory.createSimpleMessageListenerContainer()).thenReturn(listenerContainer);
+
+        sut.setConcurrency(3);
+        sut.afterPropertiesSet();
+        sut.destroy();
+
+        verify(listenerContainer, times(3)).destroy();
+    }
+
+    @Test
+    void shouldReturnTrueIfAnyContainerIsRunning() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+        when(listenerContainerFactory.createSimpleMessageListenerContainer()).thenReturn(listenerContainer);
+
+        when(listenerContainer.isRunning("test1")).thenReturn(false, true);
+
+        sut.setConcurrency(2);
+        sut.afterPropertiesSet();
+
+        assertThat(sut.isRunning("test1")).isTrue();
+        verify(listenerContainer, times(2)).isRunning("test1");
+    }
+
+    @Test
+    void shouldReturnFalseIfNoContainerIsRunning() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+        when(listenerContainerFactory.createSimpleMessageListenerContainer()).thenReturn(listenerContainer);
+
+        when(listenerContainer.isRunning("test1")).thenReturn(false);
+
+        sut.setConcurrency(2);
+        sut.afterPropertiesSet();
+
+        assertThat(sut.isRunning("test1")).isFalse();
+        verify(listenerContainer, times(2)).isRunning("test1");
+    }
+
+    @Test
+    void shouldReturnQueues() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1", "test2");
+
+        assertThat(sut.getQueues()).containsExactly("test1", "test2");
+    }
+
+    @Test
+    void shouldSetTaskExecutor(@Mock AsyncTaskExecutor taskExecutor) {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+
+        sut.setTaskExecutor(taskExecutor);
+
+        verify(listenerContainerFactory).setTaskExecutor(taskExecutor);
+    }
+
+    @Test
+    void shouldSetMaxNumberOfMessages() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+
+        sut.setMaxNumberOfMessages(5);
+
+        verify(listenerContainerFactory).setMaxNumberOfMessages(5);
+    }
+
+    @Test
+    void shouldSetVisibilityTimeout() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+
+        sut.setVisibilityTimeout(180);
+
+        verify(listenerContainerFactory).setVisibilityTimeout(180);
+    }
+
+    @Test
+    void shouldSetWaitTimeout() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+
+        sut.setWaitTimeOut(180);
+
+        verify(listenerContainerFactory).setWaitTimeOut(180);
+    }
+
+    @Test
+    void shouldSetResourceIdResolver(@Mock ResourceIdResolver resourceIdResolver) {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+
+        sut.setResourceIdResolver(resourceIdResolver);
+
+        verify(listenerContainerFactory).setResourceIdResolver(resourceIdResolver);
+    }
+
+    @Test
+    void shouldSetAutoStartup() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+
+        sut.setAutoStartup(true);
+
+        verify(listenerContainerFactory).setAutoStartup(true);
+    }
+
+    @Test
+    void shouldSetDestinationResolver(@Mock DestinationResolver<String> destinationResolver) {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+
+        sut.setDestinationResolver(destinationResolver);
+
+        verify(listenerContainerFactory).setDestinationResolver(destinationResolver);
+    }
+
+    @Test
+    void shouldSetQueueStopTimeout() {
+        SqsInboundChannelAdapter sut = new SqsInboundChannelAdapter(amazonSQS, "test1");
+        ReflectionTestUtils.setField(sut, "simpleMessageListenerContainerFactory", listenerContainerFactory);
+        when(listenerContainerFactory.createSimpleMessageListenerContainer()).thenReturn(listenerContainer);
+
+        sut.setQueueStopTimeout(120L);
+        sut.afterPropertiesSet();
+
+        verify(listenerContainer).setQueueStopTimeout(120L);
+    }
+
+}


### PR DESCRIPTION
This moves away from the Spring Integration AWS adapter to our own inbound adapter to support having multiple message listening threads at the same time. This should lead to better scaling options with this binder.

There are a few open questions before I can mark this ready for review:
- As far as I understood it the `SimpleMessageListenerContainer` will still wait for all messages to be processed before requesting a new batch. This means that if you have a single message taking a long time out of a batch of 10 you potentially lose 9 threads that would otherwise be doing work, because the container awaits for the execution to finish. Is that okay or do we need a more sophisticated solution here?
- What's a good way to test the concurrency?
- Should we update the producer to use a `MessageHandler` within this project as well? That would probably allow us to drop the dependency on spring-integration-aws altogether.

Closes #35 