### PR TITLE
feat: add property for queueStopTimeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ You may also provide additional configuration options:
   - **maxNumberOfMessages** - Maximum number of messages to retrieve with one poll to SQS. Must be a number between 1 and 10.
   - **visibilityTimeout** - The duration in seconds that polled messages are hidden from subsequent poll requests after having been retrieved.
   - **waitTimeout** - The duration in seconds that the system will wait for new messages to arrive when polling. Uses the Amazon SQS long polling feature. The value should be between 1 and 20.
+  - **queueStopTimeout** - The number of milliseconds that the queue worker is given to gracefully finish its work on shutdown before interrupting the current thread. Default value is 20000 milliseconds (20 seconds).
   - **messageDeletionPolicy** - The deletion policy for messages that are retrieved from SQS. Defaults to NO_REDRIVE.
   - **snsFanout** - Whether the incoming message has the SNS format and should be deserialized automatically. Defaults to true.
 

--- a/src/main/java/de/idealo/spring/stream/binder/sqs/SqsMessageHandlerBinder.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sqs/SqsMessageHandlerBinder.java
@@ -68,6 +68,10 @@ public class SqsMessageHandlerBinder
         adapter.setVisibilityTimeout(properties.getExtension().getVisibilityTimeout());
         adapter.setWaitTimeOut(properties.getExtension().getWaitTimeout());
 
+        if (properties.getExtension().getQueueStopTimeout() != null) {
+            adapter.setQueueStopTimeout(properties.getExtension().getQueueStopTimeout());
+        }
+
         if (properties.getExtension().getMessageDeletionPolicy() != null) {
             adapter.setMessageDeletionPolicy(properties.getExtension().getMessageDeletionPolicy());
         }

--- a/src/main/java/de/idealo/spring/stream/binder/sqs/properties/SqsConsumerProperties.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sqs/properties/SqsConsumerProperties.java
@@ -34,7 +34,7 @@ public class SqsConsumerProperties {
      *
      * {@link io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory#setQueueStopTimeout(Long)}
      */
-    private Integer queueStopTimeout;
+    private Long queueStopTimeout;
 
     /**
      * The deletion policy for messages that are retrieved from SQS. Defaults to NO_REDRIVE.
@@ -71,11 +71,11 @@ public class SqsConsumerProperties {
         this.waitTimeout = waitTimeout;
     }
 
-    public Integer getQueueStopTimeout() {
+    public Long getQueueStopTimeout() {
         return queueStopTimeout;
     }
 
-    public void setQueueStopTimeout(Integer queueStopTimeout) {
+    public void setQueueStopTimeout(Long queueStopTimeout) {
         this.queueStopTimeout = queueStopTimeout;
     }
 

--- a/src/main/java/de/idealo/spring/stream/binder/sqs/properties/SqsConsumerProperties.java
+++ b/src/main/java/de/idealo/spring/stream/binder/sqs/properties/SqsConsumerProperties.java
@@ -29,6 +29,14 @@ public class SqsConsumerProperties {
     private Integer waitTimeout;
 
     /**
+     * The number of milliseconds that the queue worker is given to gracefully finish its work on shutdown before
+     * interrupting the current thread. Default value is 20000 milliseconds (20 seconds).
+     *
+     * {@link io.awspring.cloud.messaging.config.SimpleMessageListenerContainerFactory#setQueueStopTimeout(Long)}
+     */
+    private Integer queueStopTimeout;
+
+    /**
      * The deletion policy for messages that are retrieved from SQS. Defaults to NO_REDRIVE.
      */
     private SqsMessageDeletionPolicy messageDeletionPolicy;
@@ -61,6 +69,14 @@ public class SqsConsumerProperties {
 
     public void setWaitTimeout(Integer waitTimeout) {
         this.waitTimeout = waitTimeout;
+    }
+
+    public Integer getQueueStopTimeout() {
+        return queueStopTimeout;
+    }
+
+    public void setQueueStopTimeout(Integer queueStopTimeout) {
+        this.queueStopTimeout = queueStopTimeout;
     }
 
     public SqsMessageDeletionPolicy getMessageDeletionPolicy() {


### PR DESCRIPTION
This property should be helpful for users that want to gracefully shutdown queue workers with tasks that take longer than the default of 20 seconds.

The property is simply passed along the chain to the upstream code, which handles the implementation. Unfortunately, the upstream code does not have a getter for it, so I couldn't write a simple test for this.